### PR TITLE
Add cmake test app

### DIFF
--- a/BertecCMake/.gitignore
+++ b/BertecCMake/.gitignore
@@ -1,0 +1,2 @@
+build
+install

--- a/BertecCMake/CMakeLists.txt
+++ b/BertecCMake/CMakeLists.txt
@@ -1,0 +1,34 @@
+cmake_minimum_required(VERSION 3.14.3)
+project(ClosedLoopFeedback)
+
+set(BERTEC_FOLDER_NAME "BertecSDKOctober2019")
+set(BERTEC_ZIP_NAME "${BERTEC_FOLDER_NAME}.zip")
+if(EXISTS ${CMAKE_CURRENT_BINARY_DIR}/_deps/BertecSDKOctober2019)
+    message(STATUS "Bertec is pre-downloaded, skipping download. Delete build directory if you want to re-download.")
+else()
+    message(STATUS "Downloading Bertec SDK...")
+    file(DOWNLOAD https://downloads.bertec.com/Bertec_Device_SDK_October_2019.zip ${CMAKE_CURRENT_BINARY_DIR}/_deps/${BERTEC_ZIP_NAME} SHOW_PROGRESS)
+    file(ARCHIVE_EXTRACT INPUT ${CMAKE_CURRENT_BINARY_DIR}/_deps/${BERTEC_ZIP_NAME}
+        DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/_deps/BertecSDKOctober2019
+        VERBOSE
+    )
+endif()
+
+# set(CMAKE_CXX_STANDARD 11)
+add_executable(DemoLinkageExe main.cpp)
+
+# Load the library into CMake
+# We may be able to call "regsvr32 BertecDevice.lib", but that fails on all of them so far
+# TODO determine when to use the x64 directory
+add_library(Bertec ${CMAKE_CURRENT_BINARY_DIR}/_deps/BertecSDKOctober2019/BertecDevice.lib)
+
+# Create an alias (modern cmake style) so we can be sure it is found for linking
+add_library(Bertec::bertec ALIAS Bertec)
+# Because CMake cannot determine the linker language on it's own, set it to C++ here
+set_target_properties(Bertec PROPERTIES LINKER_LANGUAGE CXX)
+
+# Now we include directories, again, using brittle absolute paths
+target_include_directories(Bertec PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/_deps/BertecSDKOctober2019)
+
+# Finally, link the Bertec Library to the add_executable
+target_link_libraries(DemoLinkageExe PUBLIC Bertec::bertec)

--- a/BertecCMake/CMakeLists.txt
+++ b/BertecCMake/CMakeLists.txt
@@ -14,29 +14,37 @@ else()
     )
 endif()
 
+if(WIN32)
+    # Prefix all shared libraries with 'lib'.
+    set(CMAKE_SHARED_LIBRARY_PREFIX "")
+    # Prefix all static libraries with 'lib'.
+    set(CMAKE_STATIC_LIBRARY_PREFIX "")
+endif()
+
 # Allow selecting static or dynamic
 # https://cmake.org/cmake/help/latest/guide/tutorial/Selecting%20Static%20or%20Shared%20Libraries.html#step-9-selecting-static-or-shared-libraries
-option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
+option(BUILD_SHARED_LIBS "Build using shared libraries" OFF)
 
-# set(CMAKE_CXX_STANDARD 11)
-add_executable(DemoLinkageExe main.cpp)
+
 
 # Load the library into CMake
 # We may be able to call "regsvr32 BertecDevice.lib", but that fails on all of them so far
 # TODO determine when to use the x64 directory
-if(${BUILD_SHARED_LIBS})
-    add_library(BertecDevice STATIC ${CMAKE_CURRENT_BINARY_DIR}/_deps/${BERTEC_FOLDER_NAME}/x64/BertecDevice.dll)
-else()
-    add_library(BertecDevice  SHARED ${CMAKE_CURRENT_BINARY_DIR}/_deps/${BERTEC_FOLDER_NAME}/x64/BertecDevice.lib)
-endif()
+add_library(BertecDevice ${CMAKE_CURRENT_BINARY_DIR}/_deps/${BERTEC_FOLDER_NAME}/x64/BertecDevice.lib)
 
 # Create an alias (modern cmake style) so we can be sure it is found for linking
 add_library(Bertec::BertecDevice ALIAS BertecDevice)
 # Because CMake cannot determine the linker language on it's own, set it to C++ here
-set_target_properties(BertecDevice PROPERTIES LINKER_LANGUAGE CXX)
+set_target_properties(BertecDevice PROPERTIES LINKER_LANGUAGE C)
 
 # Now we include directories, again, using brittle absolute paths
 target_include_directories(BertecDevice PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/_deps/${BERTEC_FOLDER_NAME})
 
+# Try building the bertec example
+add_executable(BertecExample ${CMAKE_CURRENT_BINARY_DIR}/_deps/${BERTEC_FOLDER_NAME}/BertecExample.cpp)
+target_link_libraries(BertecExample PUBLIC Bertec::BertecDevice)
+set_target_properties(BertecExample PROPERTIES LINKER_LANGUAGE C)
+
 # Finally, link the Bertec Library to the add_executable
-target_link_libraries(DemoLinkageExe PUBLIC Bertec::BertecDevice)
+# add_executable(DemoLinkageExe main.cpp)
+# target_link_libraries(DemoLinkageExe PUBLIC Bertec::BertecDevice)

--- a/BertecCMake/CMakeLists.txt
+++ b/BertecCMake/CMakeLists.txt
@@ -20,15 +20,15 @@ add_executable(DemoLinkageExe main.cpp)
 # Load the library into CMake
 # We may be able to call "regsvr32 BertecDevice.lib", but that fails on all of them so far
 # TODO determine when to use the x64 directory
-add_library(Bertec ${CMAKE_CURRENT_BINARY_DIR}/_deps/BertecSDKOctober2019/BertecDevice.lib)
+add_library(BertecDevice ${CMAKE_CURRENT_BINARY_DIR}/_deps/BertecSDKOctober2019/x64/BertecDevice.lib)
 
 # Create an alias (modern cmake style) so we can be sure it is found for linking
-add_library(Bertec::bertec ALIAS Bertec)
+add_library(Bertec::BertecDevice ALIAS BertecDevice)
 # Because CMake cannot determine the linker language on it's own, set it to C++ here
-set_target_properties(Bertec PROPERTIES LINKER_LANGUAGE CXX)
+set_target_properties(BertecDevice PROPERTIES LINKER_LANGUAGE CXX)
 
 # Now we include directories, again, using brittle absolute paths
-target_include_directories(Bertec PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/_deps/BertecSDKOctober2019)
+target_include_directories(BertecDevice PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/_deps/BertecSDKOctober2019)
 
 # Finally, link the Bertec Library to the add_executable
-target_link_libraries(DemoLinkageExe PUBLIC Bertec::bertec)
+target_link_libraries(DemoLinkageExe PUBLIC Bertec::BertecDevice)

--- a/BertecCMake/CMakeLists.txt
+++ b/BertecCMake/CMakeLists.txt
@@ -14,13 +14,21 @@ else()
     )
 endif()
 
+# Allow selecting static or dynamic
+# https://cmake.org/cmake/help/latest/guide/tutorial/Selecting%20Static%20or%20Shared%20Libraries.html#step-9-selecting-static-or-shared-libraries
+option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
+
 # set(CMAKE_CXX_STANDARD 11)
 add_executable(DemoLinkageExe main.cpp)
 
 # Load the library into CMake
 # We may be able to call "regsvr32 BertecDevice.lib", but that fails on all of them so far
 # TODO determine when to use the x64 directory
-add_library(BertecDevice ${CMAKE_CURRENT_BINARY_DIR}/_deps/BertecSDKOctober2019/x64/BertecDevice.lib)
+if(${BUILD_SHARED_LIBS})
+    add_library(BertecDevice STATIC ${CMAKE_CURRENT_BINARY_DIR}/_deps/BertecSDKOctober2019/x64/BertecDevice.dll)
+else()
+    add_library(BertecDevice  SHARED ${CMAKE_CURRENT_BINARY_DIR}/_deps/BertecSDKOctober2019/x64/BertecDevice.lib)
+endif()
 
 # Create an alias (modern cmake style) so we can be sure it is found for linking
 add_library(Bertec::BertecDevice ALIAS BertecDevice)

--- a/BertecCMake/CMakeLists.txt
+++ b/BertecCMake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14.3)
+cmake_minimum_required(VERSION 3.18)
 project(ClosedLoopFeedback)
 
 set(BERTEC_FOLDER_NAME "BertecSDKOctober2022")

--- a/BertecCMake/CMakeLists.txt
+++ b/BertecCMake/CMakeLists.txt
@@ -1,15 +1,15 @@
 cmake_minimum_required(VERSION 3.14.3)
 project(ClosedLoopFeedback)
 
-set(BERTEC_FOLDER_NAME "BertecSDKOctober2019")
+set(BERTEC_FOLDER_NAME "BertecSDKOctober2022")
 set(BERTEC_ZIP_NAME "${BERTEC_FOLDER_NAME}.zip")
-if(EXISTS ${CMAKE_CURRENT_BINARY_DIR}/_deps/BertecSDKOctober2019)
+if(EXISTS ${CMAKE_CURRENT_BINARY_DIR}/_deps/${BERTEC_FOLDER_NAME})
     message(STATUS "Bertec is pre-downloaded, skipping download. Delete build directory if you want to re-download.")
 else()
     message(STATUS "Downloading Bertec SDK...")
-    file(DOWNLOAD https://downloads.bertec.com/Bertec_Device_SDK_October_2019.zip ${CMAKE_CURRENT_BINARY_DIR}/_deps/${BERTEC_ZIP_NAME} SHOW_PROGRESS)
+    file(DOWNLOAD https://downloads.bertec.com/Bertec_Device_SDK_August_2022.zip ${CMAKE_CURRENT_BINARY_DIR}/_deps/${BERTEC_ZIP_NAME} SHOW_PROGRESS)
     file(ARCHIVE_EXTRACT INPUT ${CMAKE_CURRENT_BINARY_DIR}/_deps/${BERTEC_ZIP_NAME}
-        DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/_deps/BertecSDKOctober2019
+        DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/_deps/${BERTEC_FOLDER_NAME}
         VERBOSE
     )
 endif()
@@ -25,9 +25,9 @@ add_executable(DemoLinkageExe main.cpp)
 # We may be able to call "regsvr32 BertecDevice.lib", but that fails on all of them so far
 # TODO determine when to use the x64 directory
 if(${BUILD_SHARED_LIBS})
-    add_library(BertecDevice STATIC ${CMAKE_CURRENT_BINARY_DIR}/_deps/BertecSDKOctober2019/x64/BertecDevice.dll)
+    add_library(BertecDevice STATIC ${CMAKE_CURRENT_BINARY_DIR}/_deps/${BERTEC_FOLDER_NAME}/x64/BertecDevice.dll)
 else()
-    add_library(BertecDevice  SHARED ${CMAKE_CURRENT_BINARY_DIR}/_deps/BertecSDKOctober2019/x64/BertecDevice.lib)
+    add_library(BertecDevice  SHARED ${CMAKE_CURRENT_BINARY_DIR}/_deps/${BERTEC_FOLDER_NAME}/x64/BertecDevice.lib)
 endif()
 
 # Create an alias (modern cmake style) so we can be sure it is found for linking
@@ -36,7 +36,7 @@ add_library(Bertec::BertecDevice ALIAS BertecDevice)
 set_target_properties(BertecDevice PROPERTIES LINKER_LANGUAGE CXX)
 
 # Now we include directories, again, using brittle absolute paths
-target_include_directories(BertecDevice PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/_deps/BertecSDKOctober2019)
+target_include_directories(BertecDevice PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/_deps/${BERTEC_FOLDER_NAME})
 
 # Finally, link the Bertec Library to the add_executable
 target_link_libraries(DemoLinkageExe PUBLIC Bertec::BertecDevice)

--- a/BertecCMake/README.md
+++ b/BertecCMake/README.md
@@ -14,8 +14,10 @@ Rachel Marbaker
 In a MSYS2 terminal, navigate to this directory, then run the following.
 ```
 cd /f/Users/Rachel/ClosedLoopControl
-# Create the makefile
+# Generate
 cmake -G "MSYS Makefiles" -S . -B build
+# OR 
+cmake -G "MinGW Makefiles" -S . -B build
 # Run the build tool (you could call make directly)
 cmake --build build
 # Run

--- a/BertecCMake/README.md
+++ b/BertecCMake/README.md
@@ -1,0 +1,47 @@
+# Closed Loop Control
+
+Rachel Marbaker
+
+## Setup
+
+* See References
+* For bertec, I tried installing the Bertec DLL... it failed to install, and also failed to uninstall.
+
+    `regsvr32 BertecDevice.dll`
+
+## Build
+
+In a MSYS2 terminal, navigate to this directory, then run the following.
+```
+cd /f/Users/Rachel/ClosedLoopControl
+# Create the makefile
+cmake -G "MSYS Makefiles" -S . -B build
+# Run the build tool (you could call make directly)
+cmake --build build
+# Run
+./build/DemoLinkageExe
+```
+
+To be convenient, you can combine them all.
+
+## Troubleshooting
+
+```
+$ cmake -G "MSYS Makefiles" -S . -B build && cmake --build build && ./build/DemoLinkageExe.exe
+-- Configuring done
+-- Generating done
+-- Build files have been written to: F:/Users/Rachel/ClosedLoopControl/build
+[ 33%] Built target Bertec
+Consolidate compiler generated dependencies of target DemoLinkageExe
+[ 66%] Linking CXX executable DemoLinkageExe.exe
+C:/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/11.3.0/../../../../x86_64-w64-mingw32/bin/ld.exe: CMakeFiles/DemoLinkageExe.dir/objects.a(main.cpp.obj):main.cpp:(.text+0x79): undefined reference to `__imp_bertec_LibraryVersion'
+collect2.exe: error: ld returned 1 exit status
+make[2]: *** [CMakeFiles/DemoLinkageExe.dir/build.make:102: DemoLinkageExe.exe] Error 1
+make[1]: *** [CMakeFiles/Makefile2:85: CMakeFiles/DemoLinkageExe.dir/all] Error 2
+make: *** [Makefile:91: all] Error 2
+```
+
+
+## References
+
+* [Setup Instructions](https://docs.google.com/document/d/1qPVCVi-5vuUVGVsCsM8hnhSn-FHlYV2f4-WbrWuzfWM/edit?usp=sharing)

--- a/BertecCMake/main.cpp
+++ b/BertecCMake/main.cpp
@@ -1,0 +1,8 @@
+#include "bertecif.h"
+#include <iostream>
+
+int main() {
+    std::cout << "Starting Bertec Demo App;)" << std::endl;
+    std::cout << "Bertec version is: " << BERTEC_LIBRARY_VERSION << "and" << bertec_LibraryVersion() << std::endl;
+    return 0;
+}


### PR DESCRIPTION
* Supports automatic download of SDK
* Currently has the following error
```
rfriedm@rfriedm-us-ll6:~/Development/personal/Treadmill/BertecCMake$ cmake -S . -B build && cmake --build build
-- Bertec is pre-downloaded, skipping download. Delete build directory if you want to re-download.
-- Configuring done
-- Generating done
-- Build files have been written to: /home/rfriedm/Development/personal/Treadmill/BertecCMake/build
[ 33%] Linking CXX static library libBertec.a
[ 33%] Built target Bertec
[ 66%] Building CXX object CMakeFiles/DemoLinkageExe.dir/main.cpp.o
[100%] Linking CXX executable DemoLinkageExe
/usr/bin/ld: CMakeFiles/DemoLinkageExe.dir/main.cpp.o: in function `main':
main.cpp:(.text+0x68): undefined reference to `bertec_LibraryVersion'
collect2: error: ld returned 1 exit status
make[2]: *** [CMakeFiles/DemoLinkageExe.dir/build.make:98: DemoLinkageExe] Error 1
make[1]: *** [CMakeFiles/Makefile2:85: CMakeFiles/DemoLinkageExe.dir/all] Error 2
make: *** [Makefile:91: all] Error 2
```